### PR TITLE
fix: align Supabase column casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,5 @@ Security:
 Notes:
 - Server exports `app` (ASGI). Do not self-run in cloud; workflow starts `uvicorn server:app`.
 - Outbound `ALLOWLIST_HOSTS` restricts HTTP calls; configure as needed.
+- Supabase tables use lowercase column names (e.g. `exhibit_id`); server queries were updated to match and avoid empty results.
+- See [`docs/enhancement_plan.md`](docs/enhancement_plan.md) for a roadmap of future improvements and best‑practice guidance.

--- a/docs/enhancement_plan.md
+++ b/docs/enhancement_plan.md
@@ -1,0 +1,37 @@
+# BurnsDB Enhancement Plan
+
+This document compiles recommendations derived from external research to improve the Burns Database (BDB) MCP server and discovery workflow. The items below highlight future directions and do not represent completed features.
+
+## 1. Advanced Query Parsing and UI Filters
+- Support fielded queries using `field:value` syntax and expose common filters (claims, issues, individuals, entities).
+- Document Boolean operators and phrase search; consider wildcard and proximity support.
+
+## 2. Vector Search Optimisation
+- Index embeddings with approximate nearest‑neighbour algorithms (e.g. pgvector IVF, Faiss) to keep semantic search fast at scale.
+- Cache frequent query embeddings to reduce repeated computation.
+
+## 3. Document Ingestion and OCR
+- Add an ingestion pipeline that OCRs PDFs/images and automatically chunks, embeds and indexes new exhibits.
+- Track ingestion status and surface errors (e.g. missing files).
+
+## 4. Machine Learning‑Assisted Review
+- Use existing relevance scores as training data for active learning or predictive coding.
+- Suggest additional relevant documents by nearest‑neighbour similarity or trained classifiers.
+
+## 5. Multi‑User Collaboration
+- Implement user accounts with roles and audit logs.
+- Allow tagging and annotation of exhibits per user to support coordinated review.
+
+## 6. Reporting and Export
+- Provide exports (CSV/PDF) of filtered exhibit sets and generate case statistics reports.
+- Support standard eDiscovery formats for interchange with other platforms.
+
+## 7. Continuous Index Updates
+- Automatically refresh text and vector indexes when exhibits or metadata change.
+- Ensure semantic search uses the latest embeddings.
+
+## 8. Documentation and Training
+- Create user‑facing guides describing search syntax, tagging workflows and defensibility considerations.
+- Include troubleshooting steps for common deployment issues (network, schema mismatch, etc.).
+
+These enhancements aim to align BDB with best practices observed in high‑value litigation discovery platforms.

--- a/server.py
+++ b/server.py
@@ -270,7 +270,8 @@ async def label_results(results: List[Dict[str, Any]]) -> Dict[str, Any]:
         desc, fname = "", ""
         if _supabase and ex:
             try:
-                q = _supabase.table("exhibits").select("description, filename").eq("Exhibit_ID", _normalize_exhibit_id(ex))
+                # Supabase uses lowercase column names; ensure we query accordingly
+                q = _supabase.table("exhibits").select("description, filename").eq("exhibit_id", _normalize_exhibit_id(ex))
                 resp = q.limit(1).execute()
                 if resp.data:
                     desc = (resp.data[0] or {}).get("description") or ""
@@ -321,7 +322,7 @@ def fetch_exhibit(exhibit_id: str) -> Dict[str, Any]:
         pages.append(buf)
     meta = {"exhibit_id": eid}
     try:
-        meta_resp = _supabase.table("exhibits").select("description,filename").eq("Exhibit_ID", eid).limit(1).execute()
+        meta_resp = _supabase.table("exhibits").select("description,filename").eq("exhibit_id", eid).limit(1).execute()
         if meta_resp.data:
             meta.update({k: v for k, v in meta_resp.data[0].items() if k in ("description", "filename")})
     except Exception:
@@ -335,13 +336,13 @@ def list_exhibits(withLabels: bool = False) -> Dict[str, Any]:
         return {"ok": False, "error": "supabase_client_not_initialized", "exhibits": []}
     try:
         data = (_supabase.table("exhibits")
-                .select("Exhibit_ID,description,filename")
+                .select("exhibit_id,description,filename")
                 .execute()).data or []
     except Exception as e:
         return {"ok": False, "error": f"fetch_error:{e}", "exhibits": []}
     out = []
     for rec in data:
-        ex = rec.get("Exhibit_ID")
+        ex = rec.get("exhibit_id")
         item = {"exhibit_id": ex, "description": rec.get("description", "")}
         if withLabels:
             item["category"] = _categorize_exhibit(rec.get("description", ""), rec.get("filename", ""))


### PR DESCRIPTION
## Summary
- fix Supabase queries to use lowercase column names (e.g. `exhibit_id`) to return results
- document schema assumption in README
- add enhancement plan outlining future improvements

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_b_68c34b95ae148331bed2ff43dbd42a28